### PR TITLE
fix: prevent ReadableStream lock during login

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,6 +1,5 @@
 import type { AppLoadContext } from '@remix-run/cloudflare';
 import { RemixServer } from '@remix-run/react';
-import { isbot } from 'isbot';
 import { renderToReadableStream } from 'react-dom/server';
 import { renderHeadToString } from 'remix-island';
 import { Head } from './root';
@@ -28,14 +27,6 @@ export default async function handleRequest(
       },
     },
   );
-
-  // Handle bot requests differently to avoid stream locking issues
-  const isBot = isbot(request.headers.get('user-agent') || '');
-
-  if (isBot) {
-    // For bots, wait for the stream to be ready before processing
-    await readable.allReady;
-  }
 
   const body = new ReadableStream({
     start(controller) {


### PR DESCRIPTION
## Summary
- avoid locking server stream by removing bot-specific `allReady` handling

## Testing
- `pnpm exec eslint app/entry.server.tsx`
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'webcontainerContext'))*

------
https://chatgpt.com/codex/tasks/task_e_689404efb3d08321bba64b3046f98723